### PR TITLE
Deploy the docs through the official GitHub Pages actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,22 +5,52 @@ on:
     branches: [master]
   workflow_dispatch:
 
+# Deploy through the official GitHub Pages actions: the site is uploaded
+# as an artifact and published directly, without a gh-pages branch and
+# without any manual configuration in Settings -> Pages
+# (actions/configure-pages enables Pages through the API).
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy:
-    name: Build and deploy documentation
+  build:
+    name: Build documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
           cache: pip
       - name: Install package with docs dependencies
         run: pip install -e .[docs]
-      - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force
+      - name: Build the site
+        run: mkdocs build
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -123,10 +123,9 @@ checks (Jacobians, gradients), and end-to-end experiments (identification
 under noise, tracking).
 
 > [!NOTE]
-> The documentation site is published by the `Docs` workflow on every push to
-> `master`. After the first deployment, enable GitHub Pages once in
-> *Settings → Pages → deploy from the `gh-pages` branch*; until then the Docs
-> badge link returns a 404.
+> The documentation site is built and published automatically by the `Docs`
+> workflow on every push to `master`, through the official GitHub Pages
+> actions — no manual configuration is needed in *Settings → Pages*.
 
 ## References
 


### PR DESCRIPTION
Replace the `mkdocs gh-deploy` flow (gh-pages branch + manual *Settings → Pages* configuration) with the official GitHub Pages actions:

- `actions/configure-pages` with `enablement: true` activates GitHub Pages through the API on the first run — this works around the Settings UI failing to save the branch-based configuration (Save button returning a 404)
- `actions/upload-pages-artifact` + `actions/deploy-pages` publish the built site directly, without the `gh-pages` branch
- The deploy job exposes the live site URL in its `github-pages` environment
- README note about the manual setup step updated accordingly

After merging, the `Docs` workflow runs on `master` and the documentation goes live at https://tomboulier.github.io/SIES/ with no manual step.

https://claude.ai/code/session_01Xi3b7GLbPnZe58aPsszyrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xi3b7GLbPnZe58aPsszyrn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Mise à jour des instructions concernant la publication automatique de la documentation sur GitHub Pages.

* **Chores**
  * Amélioration du workflow d'intégration continue pour la construction et le déploiement de la documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->