### PR TITLE
Fix docs deployment: remove configure-pages enablement flag

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,8 +35,6 @@ jobs:
         run: mkdocs build
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
-        with:
-          enablement: true
       - name: Upload site artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary

- Remove `enablement: true` from the `actions/configure-pages` step in `docs.yml`

Pages is now configured in **Settings → Pages** with "GitHub Actions" as the source (set manually). The `enablement: true` API call was causing a `403 Resource not accessible by integration` error because `GITHUB_TOKEN` cannot programmatically create a new Pages site — it can only interact with one that already exists.

Merging this will trigger the `Docs` workflow on `master` and publish the documentation to https://tomboulier.github.io/SIES/.

https://claude.ai/code/session_01Xi3b7GLbPnZe58aPsszyrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xi3b7GLbPnZe58aPsszyrn)_