### PR TITLE
Remove em dashes from all prose (README, docs, notebooks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# SIES — Shape Identification in Electro-Sensing
+# SIES: Shape Identification in Electro-Sensing
 
 [![CI](https://github.com/tomboulier/SIES/actions/workflows/ci.yml/badge.svg)](https://github.com/tomboulier/SIES/actions/workflows/ci.yml)
 [![Docs](https://github.com/tomboulier/SIES/actions/workflows/docs.yml/badge.svg)](https://tomboulier.github.io/SIES/)
@@ -24,7 +24,7 @@ Polarization Tensors**, identify shapes by **dictionary matching**, and
 ---
 
 Weakly electric fish sense their environment by emitting an electric field
-and measuring its perturbation — a beautiful inverse problem. SIES implements
+and measuring its perturbation, a beautiful inverse problem. SIES implements
 the mathematical machinery behind this *electro-sensing* paradigm: boundary
 integral equations, small-volume asymptotic expansions (GPTs), invariant
 shape descriptors, and Kalman filtering.
@@ -84,7 +84,7 @@ Filter:
 | Module | What it does |
 | --- | --- |
 | `sies.shapes` | $C^2$-smooth discretized boundaries (ellipse, flower, triangle, rectangle, banana) with exact differential geometry, rigid motions and spline resampling |
-| `sies.operators` | Layer potentials of potential theory: single layer $S_D$, Neumann–Poincaré $K_D^*$, normal derivatives — P0 boundary elements with analytic singular diagonals |
+| `sies.operators` | Layer potentials of potential theory: single layer $S_D$, Neumann–Poincaré $K_D^*$, normal derivatives, implemented as P0 boundary elements with analytic singular diagonals |
 | `sies.asymptotics` | Contracted Generalized Polarization Tensors (CGPT): boundary-integral computation, closed forms for disks/ellipses, exact transformation rules under rigid motions and scaling |
 | `sies.acquisition` | Geometry of sources/receivers: concentric circles, full or limited view, grouped arrays |
 | `sies.pde` | Conductivity problem: multistatic response simulation (multi-frequency, calibrated noise) and CGPT reconstruction (least squares + closed form) |
@@ -100,9 +100,9 @@ files, no hidden state) live in [`notebooks/`](notebooks):
 marimo edit notebooks/dictionary_matching.py
 ```
 
-- [`cgpt_pipeline.py`](notebooks/cgpt_pipeline.py) — forward & inverse CGPT pipeline, validated against closed forms
-- [`dictionary_matching.py`](notebooks/dictionary_matching.py) — full identification experiment with noise-robustness study
-- [`target_tracking.py`](notebooks/target_tracking.py) — EKF tracking of a moving target
+- [`cgpt_pipeline.py`](notebooks/cgpt_pipeline.py): forward & inverse CGPT pipeline, validated against closed forms
+- [`dictionary_matching.py`](notebooks/dictionary_matching.py): full identification experiment with noise-robustness study
+- [`target_tracking.py`](notebooks/target_tracking.py): EKF tracking of a moving target
 
 ## Development
 
@@ -125,7 +125,7 @@ under noise, tracking).
 > [!NOTE]
 > The documentation site is built and published automatically by the `Docs`
 > workflow on every push to `master`, through the official GitHub Pages
-> actions — no manual configuration is needed in *Settings → Pages*.
+> actions; no manual configuration is needed in *Settings → Pages*.
 
 ## References
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,7 +43,7 @@ translation, rotation and scaling.
 
 ### 2. Simulate measurements of an unknown target
 
-The target is a *transformed* dictionary element — the identification must
+The target is a *transformed* dictionary element, so the identification must
 succeed regardless of its position, orientation and size:
 
 ```python

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# SIES — Shape Identification in Electro-Sensing
+# SIES: Shape Identification in Electro-Sensing
 
 **SIES** is a Python library for inverse problems in electro-sensing: it
 simulates electric measurements of small inclusions, computes their
@@ -9,21 +9,21 @@ from noisy data.
 
 ## What can it do?
 
-- **Shapes** — discretized $C^2$-smooth boundaries (ellipses, flowers,
+- **Shapes**: discretized $C^2$-smooth boundaries (ellipses, flowers,
   triangles, rectangles, bananas) with exact differential geometry and rigid
   motions.
-- **Layer potentials** — boundary integral operators of potential theory:
+- **Layer potentials**: boundary integral operators of potential theory:
   single layer $S_D$, Neumann–Poincaré $K_D^*$ and their derivatives.
-- **CGPT** — contracted generalized polarization tensors, computed numerically
+- **CGPT**: contracted generalized polarization tensors, computed numerically
   for any shape and analytically for disks and ellipses, with their exact
   transformation rules under translation, rotation and scaling.
-- **Forward problem** — multistatic response (MSR) matrices of the
+- **Forward problem**: multistatic response (MSR) matrices of the
   conductivity equation, at one or several frequencies, with calibrated noise.
-- **Inverse problem** — least-squares and closed-form reconstruction of the
+- **Inverse problem**: least-squares and closed-form reconstruction of the
   CGPT from MSR data.
-- **Dictionary matching** — invariant shape descriptors and identification of
+- **Dictionary matching**: invariant shape descriptors and identification of
   an unknown target in a dictionary of shapes.
-- **Tracking** — Extended Kalman Filter estimating the position and
+- **Tracking**: Extended Kalman Filter estimating the position and
   orientation of a moving target.
 
 ## Quick example

--- a/docs/matlab.md
+++ b/docs/matlab.md
@@ -17,25 +17,25 @@ and `examples/`).
 | `+dico/+CGPT` | `sies.dictionary` | ✅ ported |
 | `+tracking` | `sies.tracking` | ✅ ported |
 | `+tools` | `sies.greens`, `sies.utils` | ✅ ported (the needed subset) |
-| `+PDE/@Helmholtz_R2`, `+asymp/+SCT` (echolocation) | — | not yet ported |
-| `+PDE/@ElectricFish`, `+PDE/@PulseImaging_R2` | — | not yet ported |
-| `+wavelet` (wavelet polarization tensors) | — | not yet ported |
+| `+PDE/@Helmholtz_R2`, `+asymp/+SCT` (echolocation) | (none) | not yet ported |
+| `+PDE/@ElectricFish`, `+PDE/@PulseImaging_R2` | (none) | not yet ported |
+| `+wavelet` (wavelet polarization tensors) | (none) | not yet ported |
 | `examples/` (demo scripts) | `notebooks/` (Marimo) | ✅ ported |
 
 ## Notable differences
 
-- **Indices** — Python indices are 0-based; source `s` in MATLAB corresponds
+- **Indices**: Python indices are 0-based; source `s` in MATLAB corresponds
   to source `s - 1` in Python.
-- **Spline resampling** — shapes with corners are smoothed with *periodic*
+- **Spline resampling**: shapes with corners are smoothed with *periodic*
   cubic splines (`scipy.interpolate.CubicSpline`), where MATLAB used
   not-a-knot splines (`csapi`); the periodic variant is the natural choice for
   closed curves.
-- **Flower perturbation exponent** — the second derivative of the flower
+- **Flower perturbation exponent**: the second derivative of the flower
   boundary for perturbation exponents `k > 1` follows the correct analytic
   formula (the MATLAB code had a typo in a branch never exercised, since it
   always used `k = 1`).
-- **Operator overloading** — MATLAB overloaded `<` for rotations; Python uses
+- **Operator overloading**: MATLAB overloaded `<` for rotations; Python uses
   the explicit `shape.rotate(phi)`. Translation (`+`, `-`) and scaling (`*`)
   are kept.
-- **Randomness** — all stochastic functions accept a `numpy.random.Generator`
+- **Randomness**: all stochastic functions accept a `numpy.random.Generator`
   for reproducibility.

--- a/docs/notebooks.md
+++ b/docs/notebooks.md
@@ -26,7 +26,7 @@ it with the theoretical value and with the closed-form ellipse formulas.
 
 The complete identification experiment of the FoCM 2014 paper: a dictionary
 of shapes, an unknown (transformed) target, noisy measurements, and
-identification by invariant shape descriptors — including a study of the
+identification by invariant shape descriptors, including a study of the
 robustness to noise.
 
 ![Matching results](assets/matching_results.png)

--- a/notebooks/cgpt_pipeline.py
+++ b/notebooks/cgpt_pipeline.py
@@ -96,8 +96,8 @@ def _(mo):
         $$\phi_m = (\lambda I - K_D^*)^{-1}
         \left[\partial_\nu \mathrm{Re}/\mathrm{Im}(z^m)\right]$$
 
-        on the boundary. For ellipses, an exact formula is known (M. Lim) —
-        the two must agree to machine precision.
+        on the boundary. For ellipses, an exact formula is known (M. Lim),
+        and the two must agree to machine precision.
         """
     )
     return

--- a/notebooks/dictionary_matching.py
+++ b/notebooks/dictionary_matching.py
@@ -20,7 +20,7 @@ def _():
 
         1. build a **dictionary** of reference shapes and their invariant
            descriptors,
-        2. simulate noisy measurements of an **unknown target** — a rotated,
+        2. simulate noisy measurements of an **unknown target**: a rotated,
            scaled and translated dictionary element,
         3. reconstruct its CGPT, compute its descriptors, and **identify**
            it in the dictionary.
@@ -151,7 +151,7 @@ def _(mo):
         As in the original paper, identification is perfect at low noise
         and degrades around 5–10% noise, where shapes with similar
         low-order descriptors (the flat ellipse and the 2:1 rectangle)
-        start to be confused — lowering the comparison order helps.
+        start to be confused; lowering the comparison order helps.
         """
     )
     return


### PR DESCRIPTION
## Summary

A language and typography pass over all the prose (README, documentation pages, notebook narratives):

- **English check**: all texts were already in English. The only "French-looking" tokens are the variable name `avec` (the *acceleration vector*, alongside `tvec`) and the proper noun *Neumann-Poincaré*, both intentional and unchanged.
- **Em dashes removed everywhere**: each occurrence was replaced with a colon, comma, semicolon or a small rephrasing, never a blind substitution. In the MATLAB correspondence table, the em dash placeholder for modules without a Python counterpart becomes `(none)`.

No code changes; both notebooks still compile.

## Files touched

`README.md`, `docs/index.md`, `docs/getting-started.md`, `docs/matlab.md`, `docs/notebooks.md`, `notebooks/cgpt_pipeline.py`, `notebooks/dictionary_matching.py`

https://claude.ai/code/session_01Xi3b7GLbPnZe58aPsszyrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xi3b7GLbPnZe58aPsszyrn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Documentation**
  * Amélioration du formatage et de la cohérence typographique dans la documentation générale (README, guides de démarrage et pages de référence).
  * Mise à jour du guide MATLAB incluant les modules non encore portés et réorganisation de la section sur les différences notables.
  * Clarification des descriptions de notebooks avec reformulation ponctuelle des explications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->